### PR TITLE
Display directory name in CLI output if `package.name` is absent

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
-import { createContainer, InjectionMode, asFunction, asValue } from 'awilix'
+import { createContainer, InjectionMode, asFunction } from 'awilix'
 import chalk from 'chalk'
+import * as path from 'path'
 import * as C from './cli-util'
 import { ITypeSyncer, ITypeDefinition, ISyncedFile } from './types'
 import { createTypeSyncer } from './type-syncer'
@@ -82,9 +83,12 @@ function renderSyncedFile(file: ISyncedFile) {
     file.newTypings.length === 0
       ? chalk`{blue.bold (no new typings added)}`
       : chalk`{green.bold (${file.newTypings.length.toString()} new typings added)}`
-  const title = chalk`📦 ${file.package.name} {gray.italic — ${
+
+  const dirName = path.basename(path.dirname(path.resolve(file.filePath)))
+  const title = chalk`📦 ${file.package.name || dirName} {gray.italic — ${
     file.filePath
   }} ${badge}`
+
   const nl = '\n'
   return (
     title +

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ export interface IPackageJSONService {
  * Package.json file.
  */
 export interface IPackageFile {
-  name: string
+  name?: string
   dependencies?: IDependenciesSection
   devDependencies?: IDependenciesSection
   peerDependencies?: IDependenciesSection


### PR DESCRIPTION
First of all, great job on this package! It helps a lot with installing dependencies in TypeScript projects and the CLI output is really pretty.

However, I've found one small problem which is that when you don't specify a `name` in your project's `package.json`, the CLI output shows `undefined`:
![](https://user-images.githubusercontent.com/29176678/54087126-3e1c5680-4350-11e9-807b-1c3d97724fa0.png)
*If you're wondering why anyone would not specify a package name: It's simply redundant for "top-level packages" like back- or front-end codebases since they are not meant to be used as package dependencies.*

My PR makes the package name fall back to the directory name which is helpful enough in most cases:
![](https://user-images.githubusercontent.com/29176678/54087256-41641200-4351-11e9-96b7-f7ceca56182a.png)

