### PR TITLE
ignore node_modules packege.json for workspace

### DIFF
--- a/src/globber.ts
+++ b/src/globber.ts
@@ -21,7 +21,7 @@ export function createGlobber() {
   return {
     globPackageFiles(pattern: string) {
       return new Promise<Array<string>>((resolve, reject) =>
-        glob(path.join(pattern, 'package.json'), (err, matches) =>
+        glob(path.join(pattern, 'package.json'), {ignore: '**/node_modules/**'}, (err, matches) =>
           err
             ? /* istanbul ignore next: errors are for people who don't know what they are doing */
               reject(err)


### PR DESCRIPTION
When I use workspaces, the package.json in node_modules is also targeted.