### PR TITLE
feat: Read registry from npm config

### DIFF
--- a/src/npm-client.ts
+++ b/src/npm-client.ts
@@ -1,13 +1,30 @@
 import axios from 'axios'
+import child from 'child_process'
+import { promisify } from 'util'
+import { memoizeAsync } from './util'
 
-const client = axios.create({
-  baseURL: 'https://registry.npmjs.org',
+const execAsync = promisify(child.exec)
+
+/**
+ * Read registry from npm config.
+ */
+export async function getNpmRegistry() {
+  const { stdout } = await execAsync('npm config get registry')
+  /* istanbul ignore next */
+  return stdout.trim() || 'https://registry.npmjs.org'
+}
+
+const getClient = memoizeAsync(async () => {
+  const registryUrl = await getNpmRegistry()
+  return axios.create({ baseURL: registryUrl })
 })
 
 /**
  * Simple wrapper around the NPM API.
  */
 export const npmClient = {
-  getPackageManifest: async (name: string) =>
-    client.get(name).then((r) => r.data),
+  getPackageManifest: async (name: string) => {
+    const client = await getClient()
+    return client.get(name).then((r) => r.data)
+  },
 }


### PR DESCRIPTION
Read the registry from `npm config`, so TypeSync can read package for some private packages or bypass some network issue.

When it fails, it will fallback to the default `https://registry.npmjs.org`.