### PR TITLE
Switch to shell script instead of postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,24 +67,45 @@ Alternatively, you can use a TypeSync config file: `.typesyncrc` or a `"typesync
 
 ## Run TypeSync Automatically After Every Install
 
-To run TypeSync and install packages automatically after every package install, use a `postinstall` script to your `package.json`:
+To run TypeSync and install packages automatically after every package install, create a file called `install-with-types.sh` with the following content:
+
+```sh
+npm install $1
+npx typesync
+npm install
+```
+
+If you use `yarn`, use this instead:
+
+```sh
+yarn add $1
+yarn typesync
+yarn
+```
+
+Run this command to make the file executable:
+
+```sh
+chmod +x install-with-types.sh
+```
+
+Add the following to `package.json`:
 
 ```json
 {
   "scripts": {
-    "postinstall": "typesync && npm install"
+    "i": "./install-with-types.sh"
   }
 }
 ```
 
-Or, if you use `yarn`:
+Then install packages like this:
 
-```json
-{
-  "scripts": {
-    "postinstall": "typesync && yarn"
-  }
-}
+```bash
+npm run i <pkg name>
+
+# Or, with yarn:
+yarn i <pkg name>
 ```
 
 # Typings packages


### PR DESCRIPTION
[npm does not run postinstall on every package install](https://npm.community/t/preinstall-npm-hook-doesnt-execute-when-installing-a-specific-package/2505) (as @mike-clark-8192 mentioned in https://github.com/jeffijoe/typesync/pull/65#issuecomment-778509942).

This switches to a bash script as an alternative.

---

Thinking about this more, it would be even nicer if `typesync` could take a package name as an argument:

```sh
typesync install <pkg name>
```

or just:

```sh
typesync <pkg name>
```

and then it would handle the installation, like [`typac`](https://github.com/ewgenius/typac) does. Then there would be no need for a shell script.