### PR TITLE
fix(cli): --dry=fail should also fail when either added or removed typings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # Oh yeah!
 language: node_js
 
+# Node 18 binaries require glibc >= 2.28
+dist: focal
+
 # Add additional versions here as appropriate.
 node_js:
   - 'stable'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,8 +71,7 @@ async function run(syncer: ITypeSyncer) {
     )
   if (
     flags.dry === 'fail' &&
-    totals.newTypings > 0 &&
-    totals.removedTypings > 0
+    (totals.newTypings > 0 || totals.removedTypings > 0)
   ) {
     C.error('Typings changed; check failed.')
     process.exitCode = 1


### PR DESCRIPTION
Now correctly checks even if only added or only removed typings. Sorry for the bad logic in the original PR.