### PR TITLE
Ignore deprecated `@typings/` packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.11.1
+
+- [#79](https://github.com/jeffijoe/typesync/issues/79):  Ignore deprecated `@typings/` packages.
+- Upgrade packages.
+
 # v0.11.0
 
 - Use `npm-registry-fetch` instead of `axios` for fetching package info from npm.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "glob": "^8.1.0",
         "npm-registry-fetch": "^14.0.5",
         "ora": "^5.1.0",
-        "semver": "^7.5.0"
+        "semver": "^7.5.1"
       },
       "bin": {
         "typesync": "bin/typesync"
@@ -25,11 +25,11 @@
         "@types/glob": "^8.1.0",
         "@types/jest": "^29.5.1",
         "@types/npm-registry-fetch": "^8.0.4",
-        "@types/semver": "^7.3.13",
+        "@types/semver": "^7.5.0",
         "jest": "^29.5.0",
         "nodemon": "^2.0.22",
         "prettier": "^2.8.8",
-        "rimraf": "^5.0.0",
+        "rimraf": "^5.0.1",
         "ts-jest": "^29.1.0",
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
@@ -1251,9 +1251,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "node_modules/@types/ssri": {
@@ -4524,12 +4524,12 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.0.tgz",
-      "integrity": "sha512-Jf9llaP+RvaEVS5nPShYFhtXIrb3LRKP281ib3So0KkeZKo2wIKyq0Re7TOSwanasA423PSr6CCIL4bP6T040g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.1.tgz",
+      "integrity": "sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==",
       "dev": true,
       "dependencies": {
-        "glob": "^10.0.0"
+        "glob": "^10.2.5"
       },
       "bin": {
         "rimraf": "dist/cjs/src/bin.js"
@@ -4551,15 +4551,15 @@
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.2.tgz",
-      "integrity": "sha512-Xsa0BcxIC6th9UwNjZkhrMtNo/MnyRL8jGCP+uEwhA5oFOCY1f2s1/oNKY47xQ0Bg5nkjsfAEIej1VeH62bDDQ==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.5.tgz",
+      "integrity": "sha512-Gj+dFYPZ5hc5dazjXzB0iHg2jKWJZYMjITXYPBRQ/xc2Buw7H0BINknRTwURJ6IC6MEFpYbLvtgVb3qD+DwyuA==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
         "minimatch": "^9.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^5.0.0 || ^6.0.2",
         "path-scurry": "^1.7.0"
       },
       "bin": {
@@ -4616,9 +4616,9 @@
       "optional": true
     },
     "node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6596,9 +6596,9 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "@types/ssri": {
@@ -9051,12 +9051,12 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rimraf": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.0.tgz",
-      "integrity": "sha512-Jf9llaP+RvaEVS5nPShYFhtXIrb3LRKP281ib3So0KkeZKo2wIKyq0Re7TOSwanasA423PSr6CCIL4bP6T040g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.1.tgz",
+      "integrity": "sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==",
       "dev": true,
       "requires": {
-        "glob": "^10.0.0"
+        "glob": "^10.2.5"
       },
       "dependencies": {
         "brace-expansion": {
@@ -9069,15 +9069,15 @@
           }
         },
         "glob": {
-          "version": "10.2.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.2.tgz",
-          "integrity": "sha512-Xsa0BcxIC6th9UwNjZkhrMtNo/MnyRL8jGCP+uEwhA5oFOCY1f2s1/oNKY47xQ0Bg5nkjsfAEIej1VeH62bDDQ==",
+          "version": "10.2.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.5.tgz",
+          "integrity": "sha512-Gj+dFYPZ5hc5dazjXzB0iHg2jKWJZYMjITXYPBRQ/xc2Buw7H0BINknRTwURJ6IC6MEFpYbLvtgVb3qD+DwyuA==",
           "dev": true,
           "requires": {
             "foreground-child": "^3.1.0",
             "jackspeak": "^2.0.3",
             "minimatch": "^9.0.0",
-            "minipass": "^5.0.0",
+            "minipass": "^5.0.0 || ^6.0.2",
             "path-scurry": "^1.7.0"
           }
         },
@@ -9107,9 +9107,9 @@
       "optional": true
     },
     "semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -54,17 +54,17 @@
     "glob": "^8.1.0",
     "npm-registry-fetch": "^14.0.5",
     "ora": "^5.1.0",
-    "semver": "^7.5.0"
+    "semver": "^7.5.1"
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",
     "@types/jest": "^29.5.1",
     "@types/npm-registry-fetch": "^8.0.4",
-    "@types/semver": "^7.3.13",
+    "@types/semver": "^7.5.0",
     "jest": "^29.5.0",
     "nodemon": "^2.0.22",
     "prettier": "^2.8.8",
-    "rimraf": "^5.0.0",
+    "rimraf": "^5.0.1",
     "ts-jest": "^29.1.0",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",

--- a/src/__tests__/type-syncer.test.ts
+++ b/src/__tests__/type-syncer.test.ts
@@ -32,6 +32,11 @@ const descriptors: IPackageTypingDescriptor[] = [
     typesPackageName: '@types/packageWithInternalTypings',
   },
   {
+    typingsName: 'packageWithDeprecatedTypings',
+    codePackageName: 'packageWithDeprecatedTypings',
+    typesPackageName: '@types/packageWithDeprecatedTypings',
+  },
+  {
     typingsName: 'package4',
     codePackageName: 'package4',
     typesPackageName: '@types/package4',
@@ -72,6 +77,7 @@ function buildSyncer() {
       package3: '^1.0.0',
       packageWithInternalTypings: '^1.0.0',
       packageWithOldTypings: '^1.0.0',
+      packageWithDeprecatedTypings: '^2.0.0',
     },
     devDependencies: {
       '@types/package4': '^1.0.0',
@@ -162,9 +168,10 @@ function buildSyncer() {
         return null
       }
 
-      return {
+      const info: IPackageInfo = {
         name,
         latestVersion: '2.0.0',
+        deprecated: name === '@types/packageWithDeprecatedTypings',
         versions: [
           {
             version: '2.0.0',
@@ -176,7 +183,8 @@ function buildSyncer() {
             containsInternalTypings: name === 'packageWithInternalTypings',
           },
         ],
-      } as IPackageInfo
+      }
+      return info
     }),
   }
 

--- a/src/package-source.ts
+++ b/src/package-source.ts
@@ -40,6 +40,7 @@ export function createPackageSource(): IPackageSource {
 
       return {
         name: data.name,
+        deprecated: Boolean(data.deprecated),
         latestVersion: data['dist-tags'].latest,
         // Sort by version, highest version first.
         versions: versions

--- a/src/type-syncer.ts
+++ b/src/type-syncer.ts
@@ -138,9 +138,8 @@ export function createTypeSyncer(
         // Look for the closest matching typings package.
         const typePackageInfo = await typePackageInfoPromise
 
-        // If the types package was not found, there's nothing else to do.
-        /* istanbul ignore next */
-        if (!typePackageInfo) {
+        // If the types package was not found, or if it was deprecated, there's nothing else to do.
+        if (!typePackageInfo || typePackageInfo.deprecated) {
           return {}
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export interface IPackageJSONService {
 export interface IPackageInfo {
   name: string
   latestVersion: string
+  deprecated: boolean
   versions: Array<IPackageVersionInfo>
 }
 


### PR DESCRIPTION
Deprecated typings packages should not be installed.

Closes #79 